### PR TITLE
fix(imu): Update IMU drivers to meet TROS requirements

### DIFF
--- a/arch/arm64/boot/dts/hobot/x5-rdk.dtsi
+++ b/arch/arm64/boot/dts/hobot/x5-rdk.dtsi
@@ -350,16 +350,18 @@
 	bmi08a:bmi08a@19 {
 		compatible = "bmi08xa";
 		reg = <0x19>;
-		interrupt-parent = <&ls_gpio1_porta>;
-		interrupts = <4 IRQ_TYPE_EDGE_RISING>;
+		interrupt-parent = <&ls_gpio0_porta>;
+		interrupts = <2 IRQ_TYPE_EDGE_RISING>;
+		accel-irq-gpio = <&ls_gpio0_porta 2 GPIO_ACTIVE_HIGH>;
 		status = "disabled";
 	};
 
 	bmi08g:bmi08g@69 {
 		compatible = "bmi08xg";
 		reg = <0x69>;
-		interrupt-parent = <&ls_gpio1_porta>;
-		interrupts = <6 IRQ_TYPE_EDGE_RISING>;
+		interrupt-parent = <&dsp_gpio_porta>;
+		interrupts = <12 IRQ_TYPE_EDGE_RISING>;
+		gyro-irq-gpio = <&dsp_gpio_porta 12 GPIO_ACTIVE_HIGH>;
 		status = "disabled";
 	};
 };
@@ -452,8 +454,9 @@
 		compatible = "bmi088_gyro";
 		reg = <0>;
 		spi-max-frequency = <5000000>;
-		interrupt-parent = <&ls_gpio1_porta>;
-		interrupts = <6 IRQ_TYPE_EDGE_RISING>;
+		interrupt-parent = <&dsp_gpio_porta>;
+		interrupts = <12 IRQ_TYPE_EDGE_RISING>;
+		gyro-irq-gpio = <&dsp_gpio_porta 12 GPIO_ACTIVE_HIGH>;
 		status = "disabled";
 	};
 
@@ -461,8 +464,9 @@
 		compatible = "bmi08a";
 		reg = <1>;
 		spi-max-frequency = <5000000>;
-		interrupt-parent = <&ls_gpio1_porta>;
-		interrupts = <4 IRQ_TYPE_EDGE_RISING>;
+		interrupt-parent = <&ls_gpio0_porta>;
+		interrupts = <2 IRQ_TYPE_EDGE_RISING>;
+		accel-irq-gpio = <&ls_gpio0_porta 2 GPIO_ACTIVE_HIGH>;
 		status = "disabled";
 	};
 };

--- a/drivers/iio/imu/bmi088/bmi08.h
+++ b/drivers/iio/imu/bmi088/bmi08.h
@@ -115,6 +115,8 @@ int8_t bmi08a_write_feature_config(const uint16_t *reg_data, struct bmi08_dev *d
  * @brief Read / Write data from the given register address of accel sensor
  */
 
+ int8_t bmi08a_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bmi08_dev *dev);
+
 /*!
  * \ingroup bmi08aApiRegs
  * \page bmi08a_api_bmi08a_get_set_regs bmi08a_get_set_regs

--- a/drivers/iio/imu/bmi088/bmi08a.c
+++ b/drivers/iio/imu/bmi088/bmi08a.c
@@ -45,6 +45,11 @@ static int8_t dev_null_ptr_check(const struct bmi08_dev *dev);
 static int8_t generic_null_ptr_check(void *data_parm);
 
 /*!
+ * @brief This API reads the data from the given register address.
+ */
+static int8_t get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bmi08_dev *dev);
+
+/*!
  *  @brief This API writes or reads the data to/from the given register address.
  *
  *  @param[in] reg_addr  : Register address from where the data to be read or write.
@@ -485,6 +490,31 @@ int8_t bmi08a_write_feature_config(const uint16_t *reg_data, struct bmi08_dev *d
 
             /* Write back updated feature space */
             rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_FEATURE_CFG, &feature_data[0], read_length, dev, SET_FUNC);
+        }
+    }
+
+    return rslt;
+}
+
+
+int8_t bmi08a_get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bmi08_dev *dev)
+{
+    int8_t rslt;
+
+    /* Check for null pointer in the device structure*/
+    rslt = dev_null_ptr_check(dev);
+    rslt |= generic_null_ptr_check((void *) reg_data);
+
+    /* Proceed if null check is fine */
+    if (rslt == BMI08_OK)
+    {
+        if (len > 0)
+        {
+            get_regs(reg_addr, reg_data, len, dev);
+        }
+        else
+        {
+            rslt = BMI08_E_RD_WR_LENGTH_INVALID;
         }
     }
 
@@ -1529,6 +1559,43 @@ static int8_t generic_null_ptr_check(void *data_parm)
 
     return rslt;
 }
+
+
+/*!
+ * @brief This API reads the data from the given register address.
+ */
+static int8_t get_regs(uint8_t reg_addr, uint8_t *reg_data, uint32_t len, struct bmi08_dev *dev)
+{
+   int8_t rslt = BMI08_OK;
+   uint16_t index;
+   uint8_t temp_buff[BMI08_MAX_LEN];
+
+   if (dev->intf == BMI08_SPI_INTF)
+   {
+       /* Configuring reg_addr for SPI Interface */
+       reg_addr = reg_addr | BMI08_SPI_RD_MASK;
+   }
+
+   /* Read the data from the register */
+   dev->intf_rslt = dev->read(reg_addr, temp_buff, (len + dev->dummy_byte), dev->intf_ptr_accel);
+
+   if (dev->intf_rslt == BMI08_INTF_RET_SUCCESS)
+   {
+       for (index = 0; index < len; index++)
+       {
+           /* Updating the data buffer */
+           reg_data[index] = temp_buff[index + dev->dummy_byte];
+       }
+   }
+   else
+   {
+       /* Failure case */
+       rslt = BMI08_E_COM_FAIL;
+   }
+
+   return rslt;
+}
+
 
 /*!
  * @brief This API writes or reads the data to/from the given register address.

--- a/drivers/iio/imu/bmi088/bmi08a_driver.c
+++ b/drivers/iio/imu/bmi088/bmi08a_driver.c
@@ -52,6 +52,12 @@
 
 /* Number of Accel frames to be extracted from FIFO */
 #define BMI08_ACC_FIFO_WM_EXTRACTED_DATA_FRAME_COUNT 100
+
+/* custom for TROS*/
+#define BMI088_MSC_DATA    0x04
+static volatile u64 irq_time_stamp = 0;
+static volatile u64 irq_count = 0;
+
 /* varaiable for fifo data frame */
 u8 *fifo_data;
 struct bmi08_sensor_data *bmi08_accel;
@@ -296,6 +302,14 @@ static int acc_feature_config_set(struct bmi08a_client_data *client_data,
 	return rslt;
 }
 
+static inline int64_t get_ktime_timestamp(void)
+{
+	struct timespec64 ts;
+
+	ktime_get_real_ts64(&ts);
+
+	return timespec64_to_ns(&ts);
+}
 /**
  *	bmi08_irq_work_func - Bottom half handler for feature interrupts.
  *	@work : Work data for the workqueue handler.
@@ -354,6 +368,29 @@ static irqreturn_t bmi08_irq_handle(int irq, void *handle)
 {
 	struct bmi08a_client_data *acc_client_data = handle;
 
+    struct bmi08_sensor_data accel_data;
+    struct bmi08_sensor_data gyro_data;
+    uint64_t irq_ts;
+	int8_t rslt;
+
+	irq_count++;
+
+	irq_ts = get_ktime_timestamp();
+	rslt = 	bmi08a_get_data(&accel_data, &acc_client_data->device);
+	rslt = 	bmi08g_get_data(&gyro_data, &acc_client_data->device);
+	if (acc_client_data->bmi_event_input) {
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.x);
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.y);
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.z);
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)gyro_data.x);
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)gyro_data.y);
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)gyro_data.z);
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)((irq_ts >> 32) & 0xFFFFFFFF));
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)(irq_ts & 0xFFFFFFFF));
+		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)irq_count);
+		input_sync(acc_client_data->bmi_event_input);
+	}
+
 	if (schedule_work(&acc_client_data->irq_work))
 		return IRQ_HANDLED;
 	return IRQ_HANDLED;
@@ -374,9 +411,11 @@ static int acc_bmi08_request_irq(struct bmi08a_client_data *acc_client_data)
 {
 	int rslt = 0;
 
-	rslt = request_irq(acc_client_data->IRQ, bmi08_irq_handle,
-					   IRQF_TRIGGER_RISING,
-					   SENSOR_NAME, acc_client_data);
+	// rslt = request_irq(acc_client_data->IRQ, bmi08_irq_handle,
+	// 				   IRQF_TRIGGER_RISING,
+	// 				   SENSOR_NAME, acc_client_data);
+	rslt = devm_request_threaded_irq(acc_client_data->dev, acc_client_data->IRQ,
+		NULL, bmi08_irq_handle, IRQF_ONESHOT|IRQF_TRIGGER_RISING|IRQF_NO_THREAD, SENSOR_NAME_FEAT, acc_client_data);
 	if (rslt < 0) {
 		PERR("request_irq failed with rslt:%d", rslt);
 		return -EIO;
@@ -718,7 +757,56 @@ static int accel_sensor_init(struct bmi08a_client_data *client_data)
 		return -EIO;
 	}
 	PINFO("Accel power mode set to NORMAL");
-	client_data->data_sync_en = 0;
+
+	/* init val for TROS custom, if not need , could del init val*/
+	// client_data->data_sync_en = 0;
+	client_data->data_sync_en = 1;
+
+	uint8_t gyr_reg_data;
+    gyr_reg_data = 0x80;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_INT_CTRL, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    gyr_reg_data = 0x05;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_INT3_INT4_IO_CONF, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    gyr_reg_data = 0x80;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_INT3_INT4_IO_MAP, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+	gyr_reg_data = 0x83;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_BANDWIDTH, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+	gyr_reg_data = 0x01;
+	rslt = bmi08g_set_regs(BMI08_REG_GYRO_RANGE, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+
+
+    uint8_t acc_reg_data;
+    acc_reg_data = 0x44;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_INT1_INT2_MAP_DATA, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x09;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_INT2_IO_CONF, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x0A;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_INT1_IO_CONF, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x02;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_RANGE, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x8A;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_CONF, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+
 	return rslt;
 }
 
@@ -1365,11 +1453,43 @@ int bmi08a_probe(struct iio_dev *bmi08x_iio_private)
 	}
 	PINFO("ACC IRQ requested");
 
+	client_data->bmi_event_input = input_allocate_device();
+	if(!client_data->bmi_event_input){
+		PERR("Failed to allocate input deviec\n");
+		rslt = -ENOMEM;
+		goto exit_err_clean;
+	}
+	client_data->bmi_event_input->name = "bmi088-sensor";
+	client_data->bmi_event_input->phys = "bmi088/input0";
+	client_data->bmi_event_input->id.bustype = BUS_I2C;
+	// client_data->bmi_event_input->dev.parent = &bmi08x_iio_private->dev;
+
+	input_set_capability(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA);
+	input_set_events_per_packet(client_data->bmi_event_input, 100);
+
+	rslt = input_register_device(client_data->bmi_event_input);
+	if(rslt){
+		PERR("Failed to register input device: %d\n", rslt);
+		input_free_device(client_data->bmi_event_input);
+		client_data->bmi_event_input = NULL;
+		goto exit_err_clean;
+	}
+	PINFO("BMI088 Input device registered successfully\n");
+
 	PINFO("sensor %s probed successfully", SENSOR_NAME);
 	bmi_fifo_init();
 	return 0;
 
 exit_err_clean:
+	if(client_data->bmi_event_input)
+	{
+		if(rslt != -ENOMEM && rslt != -EINVAL)
+		{
+			input_unregister_device(client_data->bmi_event_input);
+		}
+		input_free_device(client_data->bmi_event_input);
+		client_data->bmi_event_input = NULL;
+	}
 	bmi08x_iio_unconfigure_buffer(bmi08x_iio_private);
 	if (bmi08x_iio_private)
 		iio_device_unregister(bmi08x_iio_private);

--- a/drivers/iio/imu/bmi088/bmi08a_driver.h
+++ b/drivers/iio/imu/bmi088/bmi08a_driver.h
@@ -65,6 +65,8 @@ extern "C"
 /*********************************************************************/
 /** Name of the device driver and accel input device*/
 #define SENSOR_NAME	  "bmi08a"
+#define SENSOR_NAME_FEAT "bmi08_acc_feat"
+#define SENSOR_NAME_GYR_FEAT "bmi08_gyr_feat"
 
 #define REL_HW_STATUS				(2)
 #define REL_FEAT_STATUS				(1)
@@ -93,6 +95,7 @@ struct bmi08a_client_data {
 	struct iio_trigger *bmi_input;
 	struct iio_trigger *feat_input;
 	struct iio_trigger *gyr_feat_input;
+	struct input_dev *bmi_event_input;
 	struct regulator *vdd;
 	struct regulator *vddio;
 	struct regmap *regmap;

--- a/drivers/iio/imu/bmi088/bmi08x_driver.c
+++ b/drivers/iio/imu/bmi088/bmi08x_driver.c
@@ -64,6 +64,11 @@
 
 /* accel data lenght */
 #define BMI08_GYR_DATA_LENGHT 50
+
+#define BMI088_MSC_DATA    0x04
+static volatile u64 irq_time_stamp = 0;
+static volatile u64 irq_count = 0;
+
 /*********************************************************************/
 /* Global data */
 /*********************************************************************/
@@ -325,6 +330,15 @@ static int feature_config_set(struct bmi08_client_data *client_data,
 	return rslt;
 }
 
+static inline int64_t get_ktime_timestamp(void)
+{
+	struct timespec64 ts;
+
+	ktime_get_real_ts64(&ts);
+
+	return timespec64_to_ns(&ts);
+}
+
 /**
  *	bmi08_irq_work_func - Bottom half handler for feature interrupts.
  *	@work : Work data for the workqueue handler.
@@ -499,8 +513,31 @@ static irqreturn_t bmi08_irq_handle(int irq, void *handle)
 {
 	struct bmi08_client_data *client_data = handle;
 
-	if (schedule_work(&client_data->irq_work))
-		return IRQ_HANDLED;
+    struct bmi08_sensor_data accel_data;
+    struct bmi08_sensor_data gyro_data;
+    uint64_t irq_ts;
+	int8_t rslt;
+
+	irq_count++;
+
+	irq_ts = get_ktime_timestamp();
+	rslt = 	bmi08a_get_data(&accel_data, &client_data->device);
+	rslt = 	bmi08g_get_data(&gyro_data, &client_data->device);
+	if (client_data->bmi_event_input) {
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.x);
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.y);
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.z);
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)gyro_data.x);
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)gyro_data.y);
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)gyro_data.z);
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)((irq_ts >> 32) & 0xFFFFFFFF));
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)(irq_ts & 0xFFFFFFFF));
+		input_event(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)irq_count);
+		input_sync(client_data->bmi_event_input);
+	}
+
+	// if (schedule_work(&client_data->irq_work))
+	// 	return IRQ_HANDLED;
 	return IRQ_HANDLED;
 }
 
@@ -534,9 +571,11 @@ static int bmi08_request_irq(struct bmi08_client_data *client_data)
 {
 	int rslt = 0;
 
-	rslt = request_irq(client_data->IRQ, bmi08_irq_handle,
-					   IRQF_TRIGGER_RISING,
-					   SENSOR_NAME, client_data);
+	// rslt = request_irq(client_data->IRQ, bmi08_irq_handle,
+	// 				   IRQF_TRIGGER_RISING,
+	// 				   SENSOR_NAME, client_data);
+	rslt = devm_request_threaded_irq(client_data->dev, client_data->IRQ,
+		NULL, bmi08_irq_handle, IRQF_ONESHOT|IRQF_TRIGGER_RISING|IRQF_NO_THREAD, SENSOR_NAME_FEAT, client_data);
 	if (rslt < 0) {
 		PERR("request_irq failed with rslt:%d", rslt);
 		return -EIO;
@@ -1097,6 +1136,52 @@ static int sensor_init(struct bmi08_client_data *client_data)
 		return -EIO;
 	}
 	PINFO("Gyro power mode set to NORMAL");
+
+	/* init val for TROS custom, if not need , could del init val*/
+	uint8_t gyr_reg_data;
+    gyr_reg_data = 0x80;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_INT_CTRL, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    gyr_reg_data = 0x05;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_INT3_INT4_IO_CONF, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    gyr_reg_data = 0x80;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_INT3_INT4_IO_MAP, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+	gyr_reg_data = 0x83;
+    rslt = bmi08g_set_regs(BMI08_REG_GYRO_BANDWIDTH, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+	gyr_reg_data = 0x01;
+	rslt = bmi08g_set_regs(BMI08_REG_GYRO_RANGE, &gyr_reg_data, 1, &client_data->device);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+
+
+    uint8_t acc_reg_data;
+    acc_reg_data = 0x44;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_INT1_INT2_MAP_DATA, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x09;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_INT2_IO_CONF, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x0A;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_INT1_IO_CONF, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x02;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_RANGE, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
+    acc_reg_data = 0x8A;
+    rslt = bmi08a_get_set_regs(BMI08_REG_ACCEL_CONF, &acc_reg_data, 1, &client_data->device, SET_FUNC);
+	if (rslt == BMI08_OK)
+		bmi08_i2c_delay_us(MS_TO_US(30), &client_data->device.intf_ptr_accel);
 
 	return rslt;
 }
@@ -2233,11 +2318,43 @@ int bmi08_probe(struct iio_dev *bmi08x_iio_private)
 	}
 	PINFO("GYR IRQ requested");
 
+	client_data->bmi_event_input = input_allocate_device();
+	if(!client_data->bmi_event_input){
+		PERR("Failed to allocate input deviec\n");
+		rslt = -ENOMEM;
+		goto exit_err_clean;
+	}
+	client_data->bmi_event_input->name = "bmi088-sensor";
+	client_data->bmi_event_input->phys = "bmi088/input0";
+	client_data->bmi_event_input->id.bustype = BUS_I2C;
+	// client_data->bmi_event_input->dev.parent = &bmi08x_iio_private->dev;
+
+	input_set_capability(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA);
+	input_set_events_per_packet(client_data->bmi_event_input, 100);
+
+	rslt = input_register_device(client_data->bmi_event_input);
+	if(rslt){
+		PERR("Failed to register input device: %d\n", rslt);
+		input_free_device(client_data->bmi_event_input);
+		client_data->bmi_event_input = NULL;
+		goto exit_err_clean;
+	}
+	PINFO("BMI088 Input device registered successfully\n");
+
 	PINFO("sensor %s probed successfully", SENSOR_NAME);
 
 	return 0;
 
 exit_err_clean:
+	if(client_data->bmi_event_input)
+	{
+		if(rslt != -ENOMEM && rslt != -EINVAL)
+		{
+			input_unregister_device(client_data->bmi_event_input);
+		}
+		input_free_device(client_data->bmi_event_input);
+		client_data->bmi_event_input = NULL;
+	}
 	if (client_data->vdd) {
 		(void)regulator_disable(client_data->vdd);
 		regulator_put(client_data->vdd);

--- a/drivers/iio/imu/bmi088/bmi08x_driver.h
+++ b/drivers/iio/imu/bmi088/bmi08x_driver.h
@@ -99,6 +99,9 @@ struct bmi08_client_data {
 	struct iio_trigger *bmi_input;
 	struct iio_trigger *feat_input;
 	struct iio_trigger *gyr_feat_input;
+	struct input_dev *bmi_event_input;
+	struct gpio_desc *accel_gpiod;
+	struct gpio_desc *gyro_gpiod;
 	struct regulator *vdd;
 	struct regulator *vddio;
 	struct regmap *regmap;

--- a/drivers/iio/imu/bmi088/bmi08x_i2c.c
+++ b/drivers/iio/imu/bmi088/bmi08x_i2c.c
@@ -221,13 +221,34 @@ static int bmi08_i2c_probe(struct i2c_client *client,
 	// if (client->addr == BMI08_ACCEL_I2C_ADDR_PRIMARY) {
 	if (client->addr == BMI08_ACCEL_I2C_ADDR_SECONDARY) {
 		acc_client = client;
-		acc_irq_pin = client->irq;
-	}
+		// acc_irq_pin = client->irq;
+		client_data->accel_gpiod = devm_gpiod_get(&client->dev, "accel-irq", GPIOD_IN);
+		// int gpio = desc_to_gpio(client_data->accel_gpiod);
+		// dev_info(&client->dev, "BS accel_irq gpio = %d\n", gpio);
+		if (IS_ERR(client_data->accel_gpiod)) {
+			dev_err(&client->dev, "BS failed to get accel_irq gpio\n");
+			return PTR_ERR(client_data->accel_gpiod);
+		}
+
+		acc_irq_pin = gpiod_to_irq(client_data->accel_gpiod);
+		if (acc_irq_pin < 0)
+			return acc_irq_pin;
+		}
 
 	// if (client->addr == BMI08_GYRO_I2C_ADDR_PRIMARY) {
 	if (client->addr == BMI08_GYRO_I2C_ADDR_SECONDARY) {
 		gyro_client = client;
-		gyr_irq_pin = client->irq;
+		// gyr_irq_pin = client->irq;
+		client_data->gyro_gpiod = devm_gpiod_get(&client->dev, "gyro-irq", GPIOD_IN);
+		if (IS_ERR(client_data->gyro_gpiod)) {
+			dev_err(&client->dev, "failed to get gyro_irq gpio\n");
+			return PTR_ERR(client_data->gyro_gpiod);
+		}
+
+		gyr_irq_pin = gpiod_to_irq(client_data->gyro_gpiod);
+		if (gyr_irq_pin < 0)
+			return gyr_irq_pin;
+
 	}
 	dev_id++;
 	if (dev_id == 2) {

--- a/drivers/iio/imu/inv_icm42600/Makefile
+++ b/drivers/iio/imu/inv_icm42600/Makefile
@@ -7,6 +7,8 @@ inv-icm42600-y += inv_icm42600_accel.o
 inv-icm42600-y += inv_icm42600_temp.o
 inv-icm42600-y += inv_icm42600_buffer.o
 inv-icm42600-y += inv_icm42600_timestamp.o
+inv-icm42600-y += inv_icm42688_pkt_fsync.o
+
 
 obj-$(CONFIG_INV_ICM42600_I2C) += inv-icm42600-i2c.o
 inv-icm42600-i2c-y += inv_icm42600_i2c.o

--- a/drivers/iio/imu/inv_icm42600/inv_icm42600.h
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42600.h
@@ -70,6 +70,8 @@ enum inv_icm42600_accel_fs {
 
 /* ODR suffixed by LN or LP are Low-Noise or Low-Power mode only */
 enum inv_icm42600_odr {
+	INV_ICM42600_ODR_32KHZ_LN = 1,
+	INV_ICM42600_ODR_16KHZ_LN = 2,
 	INV_ICM42600_ODR_8KHZ_LN = 3,
 	INV_ICM42600_ODR_4KHZ_LN,
 	INV_ICM42600_ODR_2KHZ_LN,
@@ -93,6 +95,7 @@ enum inv_icm42600_filter {
 	/* Low-Power mode sensor data filter (averaging) */
 	INV_ICM42600_FILTER_AVG_1X = 1,
 	INV_ICM42600_FILTER_AVG_16X = 6,
+	INV_ICM42600_FILTER_BW_ODR_DIV_40 = 7,
 };
 
 struct inv_icm42600_sensor_conf {
@@ -144,6 +147,7 @@ struct inv_icm42600_state {
 	struct inv_icm42600_suspended suspended;
 	struct iio_dev *indio_gyro;
 	struct iio_dev *indio_accel;
+	struct iio_dev *indio_fsync;
 	uint8_t buffer[2] __aligned(IIO_DMA_MINALIGN);
 	struct inv_icm42600_fifo fifo;
 	struct {
@@ -287,6 +291,11 @@ struct inv_icm42600_state {
 /* FIFO is 2048 bytes, let 12 samples for reading latency */
 #define INV_ICM42600_FIFO_WATERMARK_MAX			(2048 - 12 * 16)
 
+#define INV_ICM42600_REG_FSYNC_CONFIG   		0x0062
+#define INV_ICM42600_FSYNC_UI_SEL 				GENMASK(6,4)
+#define INV_ICM42600_FSYNC_UI_FLAG_CLEAR_SEL		BIT(1)
+#define INV_ICM42600_FSYNC_POLARITY 				BIT(0)
+
 #define INV_ICM42600_REG_INT_CONFIG1			0x0064
 #define INV_ICM42600_INT_CONFIG1_TPULSE_DURATION	BIT(6)
 #define INV_ICM42600_INT_CONFIG1_TDEASSERT_DISABLE	BIT(5)
@@ -326,6 +335,9 @@ struct inv_icm42600_state {
 #define INV_ICM42600_REG_INTF_CONFIG4			0x107A
 #define INV_ICM42600_INTF_CONFIG4_I3C_BUS_ONLY		BIT(6)
 #define INV_ICM42600_INTF_CONFIG4_SPI_AP_4WIRE		BIT(1)
+
+#define INV_ICM42600_REG_INTF_CONFIG5			0x107B
+#define INV_ICM42600_INTF_CONFIG5_PIN9_FUNCTION_MASK GENMASK(2, 1)
 
 #define INV_ICM42600_REG_INTF_CONFIG6			0x107C
 #define INV_ICM42600_INTF_CONFIG6_MASK			GENMASK(4, 0)
@@ -398,5 +410,7 @@ int inv_icm42600_gyro_parse_fifo(struct iio_dev *indio_dev);
 struct iio_dev *inv_icm42600_accel_init(struct inv_icm42600_state *st);
 
 int inv_icm42600_accel_parse_fifo(struct iio_dev *indio_dev);
+
+struct iio_dev *inv_icm42600_fsync_init(struct inv_icm42600_state *st);
 
 #endif

--- a/drivers/iio/imu/inv_icm42600/inv_icm42600_core.c
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42600_core.c
@@ -673,6 +673,10 @@ int inv_icm42600_core_probe(struct regmap *regmap, int chip, int irq,
 	if (IS_ERR(st->indio_accel))
 		return PTR_ERR(st->indio_accel);
 
+	st->indio_fsync = inv_icm42600_fsync_init(st);
+	if (IS_ERR(st->indio_fsync))
+		return PTR_ERR(st->indio_fsync);
+
 #if defined(CONFIG_IMU_DATA_READY)
 	dev_info(dev, "timestamp is DATA_RDY_INT time\n");
 #else

--- a/drivers/iio/imu/inv_icm42600/inv_icm42600_timestamp.c
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42600_timestamp.c
@@ -58,13 +58,26 @@ void inv_icm42600_timestamp_init(struct inv_icm42600_timestamp *ts,
 
 int inv_icm42600_timestamp_setup(struct inv_icm42600_state *st)
 {
+	int ret;
 	unsigned int val;
 
 	/* enable timestamp register */
 	val = INV_ICM42600_TMST_CONFIG_TMST_TO_REGS_EN |
+		  INV_ICM42600_TMST_CONFIG_TMST_FSYNC_EN |
 	      INV_ICM42600_TMST_CONFIG_TMST_EN;
-	return regmap_update_bits(st->map, INV_ICM42600_REG_TMST_CONFIG,
+	ret = regmap_update_bits(st->map, INV_ICM42600_REG_TMST_CONFIG,
 				  INV_ICM42600_TMST_CONFIG_MASK, val);
+
+	ret |= regmap_update_bits(st->map,
+				  INV_ICM42600_REG_FSYNC_CONFIG,
+				  GENMASK(6,0), 0x12); /* FSYNC from TMST, active high */
+
+	ret |= regmap_update_bits(st->map,
+					INV_ICM42600_REG_INTF_CONFIG5,
+					INV_ICM42600_INTF_CONFIG5_PIN9_FUNCTION_MASK,
+					0x2); /* PIN9 as TMST_FSYNC */
+
+	return ret;
 }
 
 int inv_icm42600_timestamp_update_odr(struct inv_icm42600_timestamp *ts,

--- a/drivers/iio/imu/inv_icm42600/inv_icm42688_pkt_fsync.c
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42688_pkt_fsync.c
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+#include <linux/device.h>
+#include <linux/mutex.h>
+#include <linux/pm_runtime.h>
+#include <linux/regmap.h>
+#include <linux/iio/iio.h>
+#include <linux/iio/sysfs.h>
+
+#include "inv_icm42600.h"
+#include "inv_icm42600_timestamp.h"
+#include "inv_icm42688_pkt_fsync.h"
+
+static const struct iio_chan_spec inv_icm42600_fsync_channels[] = {
+    {
+        .type = IIO_TIMESTAMP,
+        .scan_index = 0,
+        .scan_type = {
+            .sign = 's',
+            .realbits = 64,
+            .storagebits = 64,
+            .endianness = IIO_CPU,
+        },
+    },
+};
+
+static const struct iio_info inv_icm42600_fsync_info = {
+    .attrs = &inv_icm42688_pkt_fsync_attr_group,  // 挂载原来的属性组
+};
+
+struct iio_dev *inv_icm42600_fsync_init(struct inv_icm42600_state *st)
+{
+    struct device *dev = regmap_get_device(st->map);
+    const char *name;
+    struct iio_dev *indio_dev;
+    int ret;
+
+    name = devm_kasprintf(dev, GFP_KERNEL, "%s-fsync", st->name);
+    if (!name)
+        return ERR_PTR(-ENOMEM);
+
+    /* 分配 IIO 设备，不需要私有数据，直接使用 st */
+    indio_dev = devm_iio_device_alloc(dev, 0);
+    if (!indio_dev)
+        return ERR_PTR(-ENOMEM);
+
+    iio_device_set_drvdata(indio_dev, st);
+    indio_dev->name = name;
+    indio_dev->info = &inv_icm42600_fsync_info;
+    indio_dev->modes = INDIO_DIRECT_MODE;
+    indio_dev->channels = inv_icm42600_fsync_channels;
+    indio_dev->num_channels = ARRAY_SIZE(inv_icm42600_fsync_channels);
+
+    ret = devm_iio_device_register(dev, indio_dev);
+    if (ret)
+        return ERR_PTR(ret);
+
+    return indio_dev;
+}
+
+static int inv_icm42688_read_pkt(struct inv_icm42600_state *st,
+				 struct inv_icm42688_fsync_pkt *pkt)
+{
+	struct device *dev = regmap_get_device(st->map);
+	struct inv_icm42600_sensor_conf conf = INV_ICM42600_SENSOR_CONF_INIT;
+	__be64 raw[2];
+	u64 p0, p1;
+	int ret;
+
+	pm_runtime_get_sync(dev);
+	mutex_lock(&st->lock);
+
+	conf.mode = INV_ICM42600_SENSOR_MODE_LOW_NOISE;
+	ret = inv_icm42600_set_gyro_conf(st, &conf, NULL);
+	if (ret)
+		goto out;
+
+	ret = inv_icm42600_set_accel_conf(st, &conf, NULL);
+	if (ret)
+		goto out;
+
+	ret = inv_icm42600_set_temp_conf(st, true, NULL);
+	if (ret)
+		goto out;
+
+	ret = regmap_bulk_read(st->map,
+			       INV_ICM42600_REG_TEMP_DATA,
+			       raw, sizeof(raw));
+	if (ret)
+		goto out;
+
+	p0 = be64_to_cpu(raw[0]);
+	p1 = be64_to_cpu(raw[1]);
+
+	/* accel */
+	pkt->accel_x = (p0 >> 32) & 0xFFFF;
+	pkt->accel_y = (p0 >> 16) & 0xFFFF;
+	pkt->accel_z = (p0 >> 0)  & 0xFFFF;
+
+	/* gyro */
+	pkt->gyro_x  = (p1 >> 48) & 0xFFFF;
+	pkt->gyro_y  = (p1 >> 32) & 0xFFFF;
+	pkt->gyro_z  = (p1 >> 16) & 0xFFFF;
+
+	/* fsync timestamp */
+	pkt->fsync_ts = p1 & 0xFFFF;
+
+out:
+	mutex_unlock(&st->lock);
+	pm_runtime_mark_last_busy(dev);
+	pm_runtime_put_autosuspend(dev);
+	return ret;
+}
+
+/* ---------- sysfs show ---------- */
+
+ssize_t inv_icm42688_pkt_fsync_show(struct device *dev,
+				   struct device_attribute *attr,
+				   char *buf)
+{
+	struct iio_dev *indio_dev = dev_to_iio_dev(dev);
+	struct inv_icm42600_state *st = iio_device_get_drvdata(indio_dev);
+	struct inv_icm42688_fsync_pkt pkt;
+	u64 hi, lo;
+	int ret;
+
+	ret = iio_device_claim_direct_mode(indio_dev);
+	if (ret)
+		return ret;
+
+	ret = inv_icm42688_read_pkt(st, &pkt);
+
+	iio_device_release_direct_mode(indio_dev);
+	if (ret)
+		return ret;
+
+	hi = ((u64)pkt.fsync_ts << 48) |
+	     ((u64)pkt.accel_x  << 32) |
+	     ((u64)pkt.accel_y  << 16) |
+	     ((u64)pkt.accel_z);
+
+	lo = ((u64)pkt.gyro_x << 48) |
+	     ((u64)pkt.gyro_y << 32) |
+	     ((u64)pkt.gyro_z << 16);
+
+	/* 输出为一个“逻辑 128bit”数 */
+	return sysfs_emit(buf, "0x%016llx 0x%016llx\n", hi, lo);
+}
+
+
+
+/* ---------- attribute ---------- */
+
+static IIO_DEVICE_ATTR(pkt_fsync, 0444,
+		       inv_icm42688_pkt_fsync_show, NULL, 0);
+
+static struct attribute *inv_icm42688_pkt_fsync_attrs[] = {
+	&iio_dev_attr_pkt_fsync.dev_attr.attr,
+	NULL,
+};
+
+const struct attribute_group inv_icm42688_pkt_fsync_attr_group = {
+	.attrs = inv_icm42688_pkt_fsync_attrs,
+};

--- a/drivers/iio/imu/inv_icm42600/inv_icm42688_pkt_fsync.h
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42688_pkt_fsync.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+#ifndef INV_ICM42688_PKT_FSYNC_H_
+#define INV_ICM42688_PKT_FSYNC_H_
+
+#include <linux/iio/iio.h>
+
+struct inv_icm42600_state;
+
+struct inv_icm42688_fsync_pkt {
+	u16 fsync_ts;
+	u16 accel_x;
+	u16 accel_y;
+	u16 accel_z;
+	u16 gyro_x;
+	u16 gyro_y;
+	u16 gyro_z;
+};
+
+/* sysfs show */
+ssize_t inv_icm42688_pkt_fsync_show(struct device *dev,
+				   struct device_attribute *attr,
+				   char *buf);
+
+/* attribute group */
+extern const struct attribute_group inv_icm42688_pkt_fsync_attr_group;
+
+#endif


### PR DESCRIPTION
- BMI088:
 - Modify BMI088 driver to report events at 2.5 ms period for both SPI and I2C.
 - I2C: replace normal interrupt with GPIO interrupt and add data reporting, enabling correct data delivery to TROS algorithm under IMU interrupt mode.
 - SPI: enable data_sync flag without modifying GPIO interrupt registration, different from I2C in bottom-half interrupt handling.

- ICM42688:
 - Add Fsync feature driver.
 - Triggering requires external signal.