### PR TITLE
iio: imu: feat [X5-4420] Add BMI088 input irq stream and ICM42688 FSY…

### DIFF
--- a/arch/arm64/boot/dts/hobot/x5-rdk.dtsi
+++ b/arch/arm64/boot/dts/hobot/x5-rdk.dtsi
@@ -328,9 +328,10 @@
 	invn_icm_i2c4: icm42688@68 {
 		compatible = "invensense,icm42688";
 		reg = <0x68>;
-		/*no interrupt pin*/
-		interrupt-parent = <&gic>;
-		interrupts = <GIC_SPI 109 IRQ_TYPE_LEVEL_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lsio_gpio0_22>;
+		interrupt-parent = <&ls_gpio0_porta>;
+		interrupts = <22 IRQ_TYPE_EDGE_FALLING>;
 		axis_map_x = <1>;
 		axis_map_y = <0>;
 		axis_map_z = <2>;
@@ -340,7 +341,7 @@
 		inven,secondary_type = "none";
 		inven,aux_type = "none";
 		inven,read_only_slave_type = "none";
-		drive-open-drain = <0>;
+		drive-open-drain;
 		status = "disabled";
 	};
 };
@@ -372,9 +373,10 @@
 	invn_icm_i2c6: icm42688@68 {
 		compatible = "invensense,icm42688";
 		reg = <0x68>;
-		/*no interrupt pin*/
-		interrupt-parent = <&gic>;
-		interrupts = <GIC_SPI 109 IRQ_TYPE_LEVEL_HIGH>;
+		pinctrl-names = "default";
+		pinctrl-0 = <&lsio_gpio0_22>;
+		interrupt-parent = <&ls_gpio0_porta>;
+		interrupts = <22 IRQ_TYPE_EDGE_FALLING>;
 		axis_map_x = <1>;
 		axis_map_y = <0>;
 		axis_map_z = <2>;
@@ -384,7 +386,7 @@
 		inven,secondary_type = "none";
 		inven,aux_type = "none";
 		inven,read_only_slave_type = "none";
-		drive-open-drain = <0>;
+		drive-open-drain;
 		status = "disabled";
 	};
 };

--- a/drivers/iio/imu/bmi088/bmi08a_driver.c
+++ b/drivers/iio/imu/bmi088/bmi08a_driver.c
@@ -28,6 +28,7 @@
 #include <linux/gpio.h>
 #include <linux/of_gpio.h>
 #include <linux/of_irq.h>
+#include <linux/gpio/consumer.h>
 
 /*********************************************************************/
 /* Own header files */
@@ -275,6 +276,8 @@ static int acc_feature_config_set(struct bmi08a_client_data *client_data,
 	case BMI088_ACC_DATA_READY:
 		accel_int_config.int_type = BMI08_ACCEL_INT_DATA_RDY;
 		client_data->acc_drdy_en = enable;
+		if (!enable)
+			client_data->acc_drdy_continuous = 0;
 		break;
 	case BMI088_ACC_FIFO_WM:
 		accel_int_config.int_type = BMI08_ACCEL_INT_FIFO_WM;
@@ -330,15 +333,22 @@ static void bmi08_irq_work_func(struct work_struct *work)
 	if (acc_client_data->acc_int_status != 0) {
 		if ((acc_client_data->acc_int_status & BMI08_ACCEL_DATA_READY_INT) &&
 			(acc_client_data->data_sync_en != 1)) {
-			PINFO("ACC DRDY INT ocurred\n");
+			// PINFO("ACC DRDY INT ocurred\n");
 			mutex_lock(&acc_client_data->lock);
 			rslt = bmi08a_get_data(&accel_data, &acc_client_data->device);
 			mutex_unlock(&acc_client_data->lock);
 			check_error("get acc data", rslt);
-			PINFO("ACC X:%d Y:%d Z:%d\n",
-				  accel_data.x, accel_data.y, accel_data.z);
-			rslt = acc_feature_config_set(acc_client_data,
-					BMI088_ACC_DATA_READY, BMI08_DISABLE);
+			// PINFO("ACC X:%d Y:%d Z:%d\n",
+			// 	  accel_data.x, accel_data.y, accel_data.z);
+			/*
+			 * Legacy sysfs path disables DRDY after one shot.
+			 * Probe sets acc_drdy_continuous to keep interrupts on.
+			 */
+			if (!acc_client_data->acc_drdy_continuous) {
+				rslt = acc_feature_config_set(acc_client_data,
+						BMI088_ACC_DATA_READY,
+						BMI08_DISABLE);
+			}
 		}
 		if ((acc_client_data->acc_int_status & BMI08_ACCEL_FIFO_FULL_INT) &&
 			(acc_client_data->acc_fifo_full_en == BMI08_ENABLE)) {
@@ -358,7 +368,7 @@ static void bmi08_irq_work_func(struct work_struct *work)
 	}
 }
 /**
- * bmi08_irq_handle - IRQ handler function.
+ * bmi08_irq_handle - IRQ handler function (same input path as bmi08x_driver.c I2C).
  * @irq : Number of irq line.
  * @handle : Instance of client data.
  *
@@ -367,17 +377,17 @@ static void bmi08_irq_work_func(struct work_struct *work)
 static irqreturn_t bmi08_irq_handle(int irq, void *handle)
 {
 	struct bmi08a_client_data *acc_client_data = handle;
-
-    struct bmi08_sensor_data accel_data;
-    struct bmi08_sensor_data gyro_data;
-    uint64_t irq_ts;
+	struct bmi08_sensor_data accel_data;
+	struct bmi08_sensor_data gyro_data;
+	uint64_t irq_ts;
 	int8_t rslt;
 
 	irq_count++;
 
 	irq_ts = get_ktime_timestamp();
-	rslt = 	bmi08a_get_data(&accel_data, &acc_client_data->device);
-	rslt = 	bmi08g_get_data(&gyro_data, &acc_client_data->device);
+	rslt = bmi08a_get_data(&accel_data, &acc_client_data->device);
+	rslt = bmi08g_get_data(&gyro_data, &acc_client_data->device);
+	(void)rslt;
 	if (acc_client_data->bmi_event_input) {
 		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.x);
 		input_event(acc_client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA, (u32)accel_data.y);
@@ -391,8 +401,6 @@ static irqreturn_t bmi08_irq_handle(int irq, void *handle)
 		input_sync(acc_client_data->bmi_event_input);
 	}
 
-	if (schedule_work(&acc_client_data->irq_work))
-		return IRQ_HANDLED;
 	return IRQ_HANDLED;
 }
 
@@ -409,13 +417,18 @@ static irqreturn_t bmi08_irq_handle(int irq, void *handle)
  */
 static int acc_bmi08_request_irq(struct bmi08a_client_data *acc_client_data)
 {
-	int rslt = 0;
+	int rslt;
+	unsigned long irq_flags;
 
-	// rslt = request_irq(acc_client_data->IRQ, bmi08_irq_handle,
-	// 				   IRQF_TRIGGER_RISING,
-	// 				   SENSOR_NAME, acc_client_data);
+	/* Match bmi08x_i2c.c: threaded registration + hardirq handler (IRQF_NO_THREAD). */
+	irq_flags = irq_get_trigger_type(acc_client_data->IRQ);
+	if (!irq_flags)
+		irq_flags = IRQF_TRIGGER_RISING;
+	irq_flags |= IRQF_ONESHOT | IRQF_NO_THREAD;
+
 	rslt = devm_request_threaded_irq(acc_client_data->dev, acc_client_data->IRQ,
-		NULL, bmi08_irq_handle, IRQF_ONESHOT|IRQF_TRIGGER_RISING|IRQF_NO_THREAD, SENSOR_NAME_FEAT, acc_client_data);
+					 NULL, bmi08_irq_handle, irq_flags,
+					 SENSOR_NAME_FEAT, acc_client_data);
 	if (rslt < 0) {
 		PERR("request_irq failed with rslt:%d", rslt);
 		return -EIO;
@@ -758,9 +771,8 @@ static int accel_sensor_init(struct bmi08a_client_data *client_data)
 	}
 	PINFO("Accel power mode set to NORMAL");
 
-	/* init val for TROS custom, if not need , could del init val*/
-	// client_data->data_sync_en = 0;
-	client_data->data_sync_en = 1;
+	/* DRDY interrupt enabled at probe; keep sync off by default */
+	client_data->data_sync_en = 0;
 
 	uint8_t gyr_reg_data;
     gyr_reg_data = 0x80;
@@ -1446,6 +1458,7 @@ int bmi08a_probe(struct iio_dev *bmi08x_iio_private)
 	}
 	PINFO("Acc chip ID : 0x%x", client_data->device.accel_chip_id);
 	client_data->sensor_init = 1;
+
 	rslt = acc_bmi08_request_irq(client_data);
 	if (rslt < 0) {
 		PERR("ACC Request irq failed");
@@ -1461,10 +1474,12 @@ int bmi08a_probe(struct iio_dev *bmi08x_iio_private)
 	}
 	client_data->bmi_event_input->name = "bmi088-sensor";
 	client_data->bmi_event_input->phys = "bmi088/input0";
-	client_data->bmi_event_input->id.bustype = BUS_I2C;
+	client_data->bmi_event_input->id.bustype =
+		(client_data->device.intf == BMI08_SPI_INTF) ? BUS_SPI : BUS_I2C;
 	// client_data->bmi_event_input->dev.parent = &bmi08x_iio_private->dev;
 
 	input_set_capability(client_data->bmi_event_input, EV_MSC, BMI088_MSC_DATA);
+	/* 9 MSC + SYN per sample; larger hint enlarges evdev ring (see evdev.c). */
 	input_set_events_per_packet(client_data->bmi_event_input, 100);
 
 	rslt = input_register_device(client_data->bmi_event_input);
@@ -1474,7 +1489,18 @@ int bmi08a_probe(struct iio_dev *bmi08x_iio_private)
 		client_data->bmi_event_input = NULL;
 		goto exit_err_clean;
 	}
-	PINFO("BMI088 Input device registered successfully\n");
+	dev_info(client_data->dev, "bmi088-sensor input dev %s, grep Handlers= /proc/bus/input/devices\n",
+		 dev_name(&client_data->bmi_event_input->dev));
+
+	client_data->acc_drdy_continuous = 1;
+	rslt = acc_feature_config_set(client_data, BMI088_ACC_DATA_READY,
+				      BMI08_ENABLE);
+	if (rslt < 0) {
+		PERR("enable accel DRDY interrupt failed: %d", rslt);
+		client_data->acc_drdy_continuous = 0;
+		goto exit_err_clean;
+	}
+	PINFO("Accel DRDY interrupt enabled at probe (continuous)");
 
 	PINFO("sensor %s probed successfully", SENSOR_NAME);
 	bmi_fifo_init();
@@ -1521,7 +1547,6 @@ int bmi08a_remove(struct iio_dev *bmi08x_iio_private)
 		if (bmi08x_iio_private)
 			iio_device_unregister(bmi08x_iio_private);
 		(void)cancel_work_sync(&client_data->irq_work);
-		(void)free_irq(client_data->IRQ, client_data);
 		if (fifo_data != NULL)
 			kfree(fifo_data);
 		if (bmi08_accel != NULL)

--- a/drivers/iio/imu/bmi088/bmi08a_driver.h
+++ b/drivers/iio/imu/bmi088/bmi08a_driver.h
@@ -99,6 +99,7 @@ struct bmi08a_client_data {
 	struct regulator *vdd;
 	struct regulator *vddio;
 	struct regmap *regmap;
+	struct gpio_desc *accel_gpiod;
 	int IRQ;
 	struct mutex lock;
 	struct work_struct irq_work;
@@ -109,6 +110,7 @@ struct bmi08a_client_data {
 	atomic_t in_suspend;
 	u8 sensor_init;
 	u8 acc_drdy_en;
+	u8 acc_drdy_continuous;
 	u8 acc_fifo_wm_en;
 	u8 acc_fifo_full_en;
 	u16 acc_fifo_wm;

--- a/drivers/iio/imu/bmi088/bmi08a_spi.c
+++ b/drivers/iio/imu/bmi088/bmi08a_spi.c
@@ -27,6 +27,7 @@
 
 
 #include <linux/gpio.h>
+#include <linux/gpio/consumer.h>
 #include <linux/of.h>
 #include <linux/of_gpio.h>
 #include <linux/platform_device.h>
@@ -66,10 +67,18 @@ struct iio_dev *a_iio_spi_dev;
  * @retval zero success
  * @retval non-zero failed
  */
-static s8 bmi08a_spi_write_block(u8 reg_addr,
-					const u8 *data, u8 len)
+static struct spi_device *bmi08a_spi_client(void *intf_ptr)
 {
-	struct spi_device *client = bmi_spi_client;
+	if (intf_ptr)
+		return (struct spi_device *)intf_ptr;
+
+	return bmi_spi_client;
+}
+
+static s8 bmi08a_spi_write_block(u8 reg_addr, const u8 *data, u8 len,
+				 void *intf_ptr)
+{
+	struct spi_device *client = bmi08a_spi_client(intf_ptr);
 	u8 buffer[BMI_MAX_BUFFER_SIZE + 1];
 	struct spi_transfer xfer = {
 		.tx_buf = buffer,
@@ -99,10 +108,10 @@ static s8 bmi08a_spi_write_block(u8 reg_addr,
  * @retval zero success
  * @retval non-zero failed
  */
-static s8 bmi08a_spi_read_block(u8 reg_addr,
-							u8 *data, uint16_t len)
+static s8 bmi08a_spi_read_block(u8 reg_addr, u8 *data, uint16_t len,
+						 void *intf_ptr)
 {
-	struct spi_device *client = bmi_spi_client;
+	struct spi_device *client = bmi08a_spi_client(intf_ptr);
 	u8 reg = reg_addr | 0x80;/* read: MSB = 1 */
 	struct spi_transfer xfer[2] = {
 		[0] = {
@@ -140,7 +149,10 @@ static s8 bmi08a_spi_write_wrapper(u8 reg_addr, const u8 *data,
 {
 	s8 err;
 
-	err = bmi08a_spi_write_block(reg_addr, data, len);
+	if (!bmi08a_spi_client(intf_ptr))
+		return -ENODEV;
+
+	err = bmi08a_spi_write_block(reg_addr, data, len, intf_ptr);
 	return err;
 }
 
@@ -160,9 +172,24 @@ static s8 bmi08a_spi_read_wrapper(u8 reg_addr, u8 *data,
 {
 	s8 err;
 
-	err = bmi08a_spi_read_block(reg_addr, data, len);
+	if (!bmi08a_spi_client(intf_ptr))
+		return -ENODEV;
+
+	err = bmi08a_spi_read_block(reg_addr, data, len, intf_ptr);
 	return err;
 }
+
+void bmi08a_spi_set_gyro_intf(void *gyro_spi)
+{
+	struct bmi08a_client_data *a_client_data;
+
+	if (!a_iio_spi_dev || !gyro_spi)
+		return;
+
+	a_client_data = iio_priv(a_iio_spi_dev);
+	a_client_data->device.intf_ptr_gyro = gyro_spi;
+}
+EXPORT_SYMBOL_GPL(bmi08a_spi_set_gyro_intf);
 
 /*!
  * @brief sensor probe function via spi bus
@@ -215,8 +242,23 @@ static int bmi08a_spi_probe(struct spi_device *client)
 	a_iio_spi_dev->modes = INDIO_DIRECT_MODE;
 	a_client_data->device.read_write_len = 16;
 	a_client_data->device.intf = BMI08_SPI_INTF;
-	a_client_data->device.intf_ptr_gyro = client;
-	a_client_data->IRQ = client->irq;
+	a_client_data->device.intf_ptr_accel = client;
+	a_client_data->device.intf_ptr_gyro = NULL;
+
+	/* Align with bmi08x_i2c.c: GPIO descriptor + gpiod_to_irq (not spi->irq). */
+	a_client_data->accel_gpiod = devm_gpiod_get(&client->dev, "accel-irq",
+						    GPIOD_IN);
+	if (IS_ERR(a_client_data->accel_gpiod)) {
+		PERR("failed to get accel-irq gpio: %ld\n",
+		     PTR_ERR(a_client_data->accel_gpiod));
+		return PTR_ERR(a_client_data->accel_gpiod);
+	}
+	a_client_data->IRQ = gpiod_to_irq(a_client_data->accel_gpiod);
+	if (a_client_data->IRQ < 0) {
+		PERR("gpiod_to_irq failed: %d\n", a_client_data->IRQ);
+		return a_client_data->IRQ;
+	}
+
 	dev_set_drvdata(&client->dev, a_iio_spi_dev);
 
 	return bmi08a_probe(a_iio_spi_dev);

--- a/drivers/iio/imu/bmi088/bmi08g_driver.c
+++ b/drivers/iio/imu/bmi088/bmi08g_driver.c
@@ -1330,12 +1330,29 @@ int bmi08g_probe(struct iio_dev *bmi08x_iio_private)
 		g_client_data->sensor_init = 1;
 	}
 
-	rslt = gyr_request_irq(g_client_data);
-	if (rslt < 0) {
-		PERR("GYR Request irq failed");
-		goto exit_err_clean;
+	/*
+	 * Shared-INT boards wire gyro+accel to one host line (usually accel INT2).
+	 * Only the accel SPI node needs interrupts in DT; gyro may omit them.
+	 */
+	if (g_client_data->GYR_IRQ > 0) {
+		rslt = gyr_request_irq(g_client_data);
+		if (rslt < 0) {
+			PERR("GYR Request irq failed");
+			goto exit_err_clean;
+		}
+		PINFO("GYR IRQ requested");
+
+		rslt = feature_config_set(g_client_data, BMI088_GYRO_DATA_READY,
+					  BMI08_ENABLE);
+		if (rslt < 0) {
+			PERR("enable gyro DRDY interrupt failed: %d", rslt);
+			goto exit_err_clean;
+		}
+		PINFO("Gyro DRDY interrupt enabled at probe");
+	} else {
+		PINFO("GYR IRQ not in DT (shared accel INT), skip gyro irq\n");
 	}
-	PINFO("GYR IRQ requested");
+
 	PINFO("sensor %s probed successfully", SENSOR_NAME);
 
 	return 0;
@@ -1382,8 +1399,10 @@ int bmi08g_remove(struct iio_dev *bmi08x_iio_private)
 		bmi08x_iio_unconfigure_buffer(bmi08x_iio_private);
 		if (bmi08x_iio_private)
 			iio_device_unregister(bmi08x_iio_private);
-		(void)cancel_work_sync(&g_client_data->gyr_irq_work);
-		(void)free_irq(g_client_data->GYR_IRQ, g_client_data);
+		if (g_client_data->GYR_IRQ > 0) {
+			(void)cancel_work_sync(&g_client_data->gyr_irq_work);
+			(void)free_irq(g_client_data->GYR_IRQ, g_client_data);
+		}
 
 	}
 

--- a/drivers/iio/imu/bmi088/bmi08g_spi.c
+++ b/drivers/iio/imu/bmi088/bmi08g_spi.c
@@ -43,6 +43,9 @@
 #include "bmi08g_driver.h"
 #include "bs_log.h"
 
+/* Exported by bmi08a_spi_driver.ko */
+extern void bmi08a_spi_set_gyro_intf(void *gyro_spi);
+
 /*********************************************************************/
 /* Local macro definitions */
 /*********************************************************************/
@@ -216,7 +219,12 @@ static int bmi08g_spi_probe(struct spi_device *client)
 	g_client_data->GYR_IRQ = client->irq;
 	dev_set_drvdata(&client->dev, g_iio_spi_dev);
 
-	return bmi08g_probe(g_iio_spi_dev);
+	err = bmi08g_probe(g_iio_spi_dev);
+	if (err)
+		goto exit_err_clean;
+
+	bmi08a_spi_set_gyro_intf(client);
+	return 0;
 exit_err_clean:
 	if (err)
 		bmi_spi_client = NULL;

--- a/drivers/iio/imu/inv_icm42600/Kconfig
+++ b/drivers/iio/imu/inv_icm42600/Kconfig
@@ -3,6 +3,7 @@
 config INV_ICM42600
 	tristate
 	select IIO_BUFFER
+	select INPUT
 
 config INV_ICM42600_I2C
 	tristate "InvenSense ICM-426xx I2C driver"

--- a/drivers/iio/imu/inv_icm42600/inv_icm42600.h
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42600.h
@@ -70,8 +70,6 @@ enum inv_icm42600_accel_fs {
 
 /* ODR suffixed by LN or LP are Low-Noise or Low-Power mode only */
 enum inv_icm42600_odr {
-	INV_ICM42600_ODR_32KHZ_LN = 1,
-	INV_ICM42600_ODR_16KHZ_LN = 2,
 	INV_ICM42600_ODR_8KHZ_LN = 3,
 	INV_ICM42600_ODR_4KHZ_LN,
 	INV_ICM42600_ODR_2KHZ_LN,
@@ -95,7 +93,6 @@ enum inv_icm42600_filter {
 	/* Low-Power mode sensor data filter (averaging) */
 	INV_ICM42600_FILTER_AVG_1X = 1,
 	INV_ICM42600_FILTER_AVG_16X = 6,
-	INV_ICM42600_FILTER_BW_ODR_DIV_40 = 7,
 };
 
 struct inv_icm42600_sensor_conf {
@@ -134,6 +131,8 @@ struct inv_icm42600_suspended {
  *  @buffer:		data transfer buffer aligned for DMA.
  *  @fifo:		FIFO management structure.
  *  @timestamp:		interrupt timestamps.
+ *  @input:		input device for irq streaming (ICM42688).
+ *  @irq_count:		interrupt sample counter for input events.
  */
 struct inv_icm42600_state {
 	struct mutex lock;
@@ -154,6 +153,8 @@ struct inv_icm42600_state {
 		int64_t gyro;
 		int64_t accel;
 	} timestamp;
+	struct input_dev *input;
+	u64 irq_count;
 };
 
 /* Virtual register addresses: @bank on MSB (4 upper bits), @address on LSB */

--- a/drivers/iio/imu/inv_icm42600/inv_icm42600_core.c
+++ b/drivers/iio/imu/inv_icm42600/inv_icm42600_core.c
@@ -16,10 +16,13 @@
 #include <linux/property.h>
 #include <linux/regmap.h>
 #include <linux/iio/iio.h>
+#include <linux/input.h>
 
 #include "inv_icm42600.h"
 #include "inv_icm42600_buffer.h"
 #include "inv_icm42600_timestamp.h"
+
+#define ICM42688_MSC_DATA	0x04
 
 static const struct regmap_range_cfg inv_icm42600_regmap_ranges[] = {
 	{
@@ -69,6 +72,23 @@ static const struct inv_icm42600_conf inv_icm42600_default_conf = {
 	.temp_en = false,
 };
 
+/* ICM42688: 1kHz ODR for input stream (align with BMI088 / sample_imu_input) */
+static const struct inv_icm42600_conf inv_icm42688_default_conf = {
+	.gyro = {
+		.mode = INV_ICM42600_SENSOR_MODE_OFF,
+		.fs = INV_ICM42600_GYRO_FS_2000DPS,
+		.odr = INV_ICM42600_ODR_1KHZ_LN,
+		.filter = INV_ICM42600_FILTER_BW_ODR_DIV_2,
+	},
+	.accel = {
+		.mode = INV_ICM42600_SENSOR_MODE_OFF,
+		.fs = INV_ICM42600_ACCEL_FS_16G,
+		.odr = INV_ICM42600_ODR_1KHZ_LN,
+		.filter = INV_ICM42600_FILTER_BW_ODR_DIV_2,
+	},
+	.temp_en = false,
+};
+
 static const struct inv_icm42600_hw inv_icm42600_hw[INV_CHIP_NB] = {
 	[INV_CHIP_ICM42600] = {
 		.whoami = INV_ICM42600_WHOAMI_ICM42600,
@@ -93,6 +113,7 @@ static const struct inv_icm42600_hw inv_icm42600_hw[INV_CHIP_NB] = {
 	[INV_CHIP_ICM40608] = {
 		.whoami = INV_ICM42600_WHOAMI_ICM40608,
 		.name = "icm40608",
+		// .conf = &inv_icm42688_default_conf,
 		.conf = &inv_icm42600_default_conf,
 	},
 	[INV_CHIP_ICM42688] = {
@@ -431,6 +452,106 @@ static int inv_icm42600_setup(struct inv_icm42600_state *st,
 	return inv_icm42600_set_conf(st, hw->conf);
 }
 
+static void inv_icm42688_input_report(struct inv_icm42600_state *st, u64 irq_ts,
+				      int16_t ax, int16_t ay, int16_t az,
+				      int16_t gx, int16_t gy, int16_t gz)
+{
+	struct input_dev *input = st->input;
+
+	st->irq_count++;
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)ax);
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)ay);
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)az);
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)gx);
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)gy);
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)gz);
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)((irq_ts >> 32) & 0xFFFFFFFF));
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)(irq_ts & 0xFFFFFFFF));
+	input_event(input, EV_MSC, ICM42688_MSC_DATA, (u32)st->irq_count);
+	input_sync(input);
+}
+
+static int inv_icm42688_input_drdy(struct inv_icm42600_state *st)
+{
+	__be16 raw[6];
+	u64 irq_ts = st->timestamp.accel;
+	int ret;
+
+	ret = regmap_bulk_read(st->map, INV_ICM42600_REG_ACCEL_DATA_X,
+			       raw, sizeof(raw));
+	if (ret)
+		return ret;
+
+	inv_icm42688_input_report(st, irq_ts,
+				  be16_to_cpu(raw[0]), be16_to_cpu(raw[1]),
+				  be16_to_cpu(raw[2]), be16_to_cpu(raw[3]),
+				  be16_to_cpu(raw[4]), be16_to_cpu(raw[5]));
+	return 0;
+}
+
+static void inv_icm42688_input_unregister(void *data)
+{
+	struct inv_icm42600_state *st = data;
+
+	if (st->input)
+		input_unregister_device(st->input);
+}
+
+static int inv_icm42688_input_init(struct inv_icm42600_state *st)
+{
+	struct device *dev = regmap_get_device(st->map);
+	struct inv_icm42600_sensor_conf conf = INV_ICM42600_SENSOR_CONF_INIT;
+	int ret;
+
+	st->input = devm_input_allocate_device(dev);
+	if (!st->input)
+		return -ENOMEM;
+
+	st->input->name = "icm42688-sensor";
+	st->input->phys = "icm42688/input0";
+	st->input->id.bustype = BUS_I2C;
+	st->input->dev.parent = dev;
+	input_set_capability(st->input, EV_MSC, ICM42688_MSC_DATA);
+	input_set_events_per_packet(st->input, 100);
+
+	ret = input_register_device(st->input);
+	if (ret)
+		return ret;
+
+	pm_runtime_get_sync(dev);
+	mutex_lock(&st->lock);
+
+	conf.mode = INV_ICM42600_SENSOR_MODE_LOW_NOISE;
+	conf.odr = INV_ICM42600_ODR_2KHZ_LN;
+	ret = inv_icm42600_set_gyro_conf(st, &conf, NULL);
+	if (!ret)
+		ret = inv_icm42600_set_accel_conf(st, &conf, NULL);
+	if (!ret) {
+		ret = regmap_update_bits(st->map, INV_ICM42600_REG_INT_SOURCE0,
+					 INV_ICM42600_INT_SOURCE0_UI_DRDY_INT1_EN,
+					 INV_ICM42600_INT_SOURCE0_UI_DRDY_INT1_EN);
+	}
+
+	mutex_unlock(&st->lock);
+	if (ret) {
+		pm_runtime_put_sync(dev);
+		input_unregister_device(st->input);
+		st->input = NULL;
+		return ret;
+	}
+
+	ret = devm_add_action(dev, inv_icm42688_input_unregister, st);
+	if (ret) {
+		pm_runtime_put_sync(dev);
+		input_unregister_device(st->input);
+		st->input = NULL;
+		return ret;
+	}
+
+	dev_info(dev, "icm42688-sensor input ready, DRDY on INT1\n");
+	return 0;
+}
+
 static irqreturn_t inv_icm42600_irq_timestamp(int irq, void *_data)
 {
 	struct inv_icm42600_state *st = _data;
@@ -479,6 +600,13 @@ static irqreturn_t inv_icm42600_irq_handler(int irq, void *_data)
 		ret = inv_icm42600_buffer_fifo_parse(st);
 		if (ret)
 			dev_err(dev, "FIFO parsing error %d\n", ret);
+	}
+
+	/* UI data ready: irq stream via input (same frame as bmi088) */
+	if ((status & INV_ICM42600_INT_STATUS_DATA_RDY) && st->input) {
+		ret = inv_icm42688_input_drdy(st);
+		if (ret)
+			dev_err(dev, "DRDY input report error %d\n", ret);
 	}
 
 out_unlock:
@@ -686,6 +814,12 @@ int inv_icm42600_core_probe(struct regmap *regmap, int chip, int irq,
 	ret = inv_icm42600_irq_init(st, irq, irq_type, open_drain);
 	if (ret)
 		return ret;
+
+	if (chip == INV_CHIP_ICM42688) {
+		ret = inv_icm42688_input_init(st);
+		if (ret)
+			return ret;
+	}
 
 	/* setup runtime power management */
 	ret = pm_runtime_set_active(dev);


### PR DESCRIPTION
…NC/input streaming

Summary:
- BMI088: EV_MSC irq stream via bmi088-sensor input, continuous DRDY at probe
- BMI088: GPIO/SPI irq path, shared-int board and dual-SPI gyro intf glue
- ICM42688: EV_MSC irq stream via icm42688-sensor input on UI DRDY interrupt
- ICM42688: FSYNC/TMST config and pkt_fsync sysfs IIO device